### PR TITLE
Increase timeouts from 15s to something reasonable

### DIFF
--- a/qbittools/qbittools.py
+++ b/qbittools/qbittools.py
@@ -63,6 +63,7 @@ def qbit_client(args):
         host=f"{args.server}:{args.port}",
         username=args.username,
         password=args.password,
+        REQUESTS_ARGS={"timeout":180.1}
     )
 
     try:


### PR DESCRIPTION
Totally ok if this isn't taken - upstream doesn't appear to work at all anymore outside of this single line fix. Orphaned has completely stopped working without this.