### PR TITLE
fix: add `not authorized` to unregistered_matches

### DIFF
--- a/qbittools/commands/tagging.py
+++ b/qbittools/commands/tagging.py
@@ -25,6 +25,7 @@ def __init__(args, logger):
 
     unregistered_matches = [
         'unregistered',
+        'not authorized',
         'not registered',
         'not found',
         'not exist',


### PR DESCRIPTION
A certain tracker uses `Torrent is not authorized for use on this tracker.`