### PR TITLE
feat: add milkie

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -131,6 +131,11 @@ trackers:
     required_seed_ratio: 1.05
     required_seed_days: 2.5
 
+  - name: milkie
+    urls: ["cow.milkie.cc"]
+    required_seed_ratio: 0
+    required_seed_days: 0
+
   - name: morethantv
     urls:
     - morethantv.me


### PR DESCRIPTION
Adds milkie tracker which is essentially public tracker with no seed/ratio requirements.

Really like the tagging feature, but without milkie it shows as `site:unregistered`. Tested on my [cluster](https://github.com/mchestr/home-cluster/blob/main/kubernetes/apps/default/qbittorrent/tools/config/config.yaml#L73-L76) and works good 👍 