### PR TITLE
Improve orphaned and prune commands

### DIFF
--- a/qbittools/commands/prune.py
+++ b/qbittools/commands/prune.py
@@ -3,11 +3,26 @@ import qbittools
 def __init__(args, logger):
     client = qbittools.qbit_client(args)
 
-    filtered_torrents = client.torrents.info()
+    categories = list(client.torrent_categories.categories.keys())
+    if len(args.include_category) > 0:
+        includes = [i for s in args.include_category for i in s]
+        categories = list(filter(
+            lambda c: c in includes,
+            categories
+        ))
+    if len(args.exclude_category) > 0:
+        excludes = [i for s in args.exclude_category for i in s]
+        categories = list(filter(
+            lambda c: c not in excludes,
+            categories
+        ))
 
-    exclude_categories = [i for s in args.exclude_category for i in s]
-    if len(exclude_categories):
-        filtered_torrents = list(filter(lambda x: x.category not in exclude_categories, filtered_torrents))
+    if len(categories) == 0:
+        logger.info(f"No torrents can be pruned since no categories were included based on selectors")
+
+    filtered_torrents = client.torrents.info()
+    filtered_torrents = list(filter(lambda x: x.category in categories, filtered_torrents))
+
     include_tags = [i for s in args.include_tag for i in s]
     if len(include_tags):
         filtered_torrents = list(filter(lambda x: all(y in x.tags for y in include_tags), filtered_torrents))
@@ -37,6 +52,7 @@ def add_arguments(subparser):
     parser = subparser.add_parser('prune')
     parser.add_argument('--include-tag', nargs='*', action='append', metavar='mytag', default=[], help='Include torrents containing all of these tags, can be repeated multiple times', required=True)
     parser.add_argument('--exclude-tag', nargs='*', action='append', metavar='mytag', default=[], help='Exclude torrents containing any of these tags, can be repeated multiple times', required=False)
+    parser.add_argument('--include-category', nargs='*', action='append', metavar='mycategory', default=[], help='Include torrents in this category, can be repeated multiple times. If not specified, all categories are included', required=False)
     parser.add_argument('--exclude-category', nargs='*', action='append', metavar='mycategory', default=[], help='Exclude torrents in this category, can be repeated multiple times', required=False)
     parser.add_argument('--dry-run', action='store_true', help='Do not delete torrents', default=False, required=False)
     parser.add_argument('--with-data', action='store_true', help='Delete torrents with data', default=False, required=False)

--- a/qbittools/commands/prune.py
+++ b/qbittools/commands/prune.py
@@ -1,3 +1,5 @@
+from fnmatch import fnmatch
+
 import qbittools
 
 def __init__(args, logger):
@@ -7,13 +9,13 @@ def __init__(args, logger):
     if len(args.include_category) > 0:
         includes = [i for s in args.include_category for i in s]
         categories = list(filter(
-            lambda c: c in includes,
+            lambda c: any(fnmatch(c, p) for p in includes),
             categories
         ))
     if len(args.exclude_category) > 0:
         excludes = [i for s in args.exclude_category for i in s]
         categories = list(filter(
-            lambda c: c not in excludes,
+            lambda c: not any(fnmatch(c, p) for p in excludes),
             categories
         ))
 
@@ -52,8 +54,8 @@ def add_arguments(subparser):
     parser = subparser.add_parser('prune')
     parser.add_argument('--include-tag', nargs='*', action='append', metavar='mytag', default=[], help='Include torrents containing all of these tags, can be repeated multiple times', required=True)
     parser.add_argument('--exclude-tag', nargs='*', action='append', metavar='mytag', default=[], help='Exclude torrents containing any of these tags, can be repeated multiple times', required=False)
-    parser.add_argument('--include-category', nargs='*', action='append', metavar='mycategory', default=[], help='Include torrents in this category, can be repeated multiple times. If not specified, all categories are included', required=False)
-    parser.add_argument('--exclude-category', nargs='*', action='append', metavar='mycategory', default=[], help='Exclude torrents in this category, can be repeated multiple times', required=False)
+    parser.add_argument('--include-category', nargs='*', action='append', metavar='mycategory', default=[], help='Include torrents only from category that matches this pattern, can be repeated multiple times. If not specified, all categories are included', required=False)
+    parser.add_argument('--exclude-category', nargs='*', action='append', metavar='mycategory', default=[], help='Exclude torrents from category that matches this pattern, can be repeated multiple times', required=False)
     parser.add_argument('--dry-run', action='store_true', help='Do not delete torrents', default=False, required=False)
     parser.add_argument('--with-data', action='store_true', help='Delete torrents with data', default=False, required=False)
     qbittools.add_default_args(parser)


### PR DESCRIPTION
Closes #37 

Orphaned now can traverse file system and delete nested files and folders. It no longer requires opinionated file structure.

Prune command supports `--include-category` which matches categories to include against the list of specified patterns. Similarly `--exclude-category` now acts as a pattern match too.

I tested these changes locally in dry-run mode, and they seem to work, but I wouldn't mind having more testing done on these :smile: 