### PR TITLE
feat: add avistaz to unregistered matches

### DIFF
--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -39,7 +39,8 @@ UNREGISTERED_MATCHES = [
     'trumped',
     'torrent existiert nicht',
     'other',
-    'i\'m sorry dave, i can\'t do that' # weird stuff from racingforme
+    'i\'m sorry dave, i can\'t do that', # weird stuff from racingforme
+    '002: invalid infohash'
 ]
 
 MAINTENANCE_MATCHES = [


### PR DESCRIPTION
Adds the unregistered match string for AvistaZ, a private tracker geared towards asian media.

The full message from qbt is here, I can adjust the string etc if requested:

![image](https://github.com/buroa/qbtools/assets/9361780/41e65322-3d87-4af1-87b3-64ce09829f21)
