### PR TITLE
Ignore trackerless torrents when attempting to tag

### DIFF
--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -80,6 +80,10 @@ def __init__(args, logger):
 
         # TODO: Optimize - this slows down the script a lot
         filtered_trackers = list(filter(lambda s: not s.url in DHT_MATCHES, t.trackers))
+        if len(filtered_trackers) == 0:
+            # ignore trackerless torrents
+            continue
+
         domain = extractTLD(sorted(filtered_trackers, key=lambda x: x.url)[0].url).registered_domain
         tracker = qbtools.utils.filter_tracker_by_domain(domain, trackers)
 


### PR DESCRIPTION
For whatever reason I had a trackerless torrent in my list which was causing qbtools to crash:
```07:06:03 PM INFO:Tagging torrents in qBittorrent...
Traceback (most recent call last):
  File "/app/qbtools.py", line 79, in <module>
    main()
  File "/app/qbtools.py", line 76, in main
    cmd = getattr(mod, "__init__")(args, logger)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/commands/tagging.py", line 82, in __init__
    domain = extractTLD(sorted(filtered_trackers, key=lambda x: x.url)[0].url).registered_domain
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

This adds a check to make sure we only attempt to tag torrents that have a tracker