### PR TITLE
feat: remove domains tag

### DIFF
--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -91,34 +91,10 @@ def __init__(app, logger):
         tracker = trackers.get(extractTLD(url).registered_domain)
 
         if app.added_on:
-            added_on = datetime.fromtimestamp(t.added_on)
-            diff = today - added_on
-
-            if diff.days == 0:
-                tags_to_add.append("added:1d")
-            elif diff.days <= 7:
-                tags_to_add.append("added:7d")
-            elif diff.days <= 30:
-                tags_to_add.append("added:30d")
-            elif diff.days <= 180:
-                tags_to_add.append("added:180d")
-            elif diff.days > 180:
-                tags_to_add.append("added:>180d")
-
+            tags_to_add.append(calculate_date_tags("added", t.added_on, today))
+        
         if app.last_activity:
-            last_activity = datetime.fromtimestamp(t.last_activity)
-            diff = datetime.today() - last_activity
-
-            if diff.days == 0:
-                tags_to_add.append("activity:1d")
-            elif diff.days <= 7:
-                tags_to_add.append("activity:7d")
-            elif diff.days <= 30:
-                tags_to_add.append("activity:30d")
-            elif diff.days <= 180:
-                tags_to_add.append("activity:180d")
-            elif diff.days > 180:
-                tags_to_add.append("activity:>180d")
+            tags_to_add.append(calculate_date_tags("activity", t.last_activity, today))
 
         if app.sites:
             if tracker:
@@ -183,6 +159,20 @@ def __init__(app, logger):
             logger.info(f"Tagged {len(new_torrents)} new torrents with tag: {tag}")
 
     logger.info("Finished tagging torrents in qBittorrent")
+
+
+def calculate_date_tags(prefix, timestamp, today):
+    diff = today - datetime.fromtimestamp(timestamp)
+    if diff.days == 0:
+        return f"{prefix}:1d"
+    elif diff.days <= 7:
+        return f"{prefix}:7d"
+    elif diff.days <= 30:
+        return f"{prefix}:30d"
+    elif diff.days <= 180:
+        return f"{prefix}:180d"
+    else:
+        return f"{prefix}:>180d"
 
 
 def add_arguments(command, subparser):

--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -245,7 +245,7 @@ def add_arguments(command, subparser):
         help="Tag torrents with not working tracker status",
     )
     parser.add_argument(
-        "--sites", action="store_true", help="Tag torrents with known site names"
+        "--sites", action="store_true", help="Tag torrents with site names (tracker URL from config.yaml)"
     )
     parser.add_argument(
         "--tracker-down",

--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -14,7 +14,6 @@ DEFAULT_TAGS = [
     "not-working",
     "unregistered",
     "tracker-down",
-    "domain:",
     "site:",
 ]
 
@@ -89,8 +88,7 @@ def __init__(app, logger):
                 continue
             url = filtered[0].url
 
-        domain = extractTLD(url).registered_domain
-        tracker = trackers.get(domain)
+        tracker = trackers.get(extractTLD(url).registered_domain)
 
         if app.added_on:
             added_on = datetime.fromtimestamp(t.added_on)
@@ -127,9 +125,6 @@ def __init__(app, logger):
                 tags_to_add.append(f"site:{tracker['name']}")
             else:
                 tags_to_add.append(f"site:unmapped")
-
-        if app.domains:
-            tags_to_add.append(f"domain:{domain}")
 
         if (app.unregistered or app.tracker_down or app.not_working) and filtered:
             tracker_messages = [z.msg.upper() for z in filtered]
@@ -223,9 +218,6 @@ def add_arguments(command, subparser):
         "--added-on",
         action="store_true",
         help="Tag torrents with added date (last 24h, 7 days, 30 days, etc)",
-    )
-    parser.add_argument(
-        "--domains", action="store_true", help="Tag torrents with tracker domains"
     )
     parser.add_argument(
         "--duplicates",

--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -245,7 +245,7 @@ def add_arguments(command, subparser):
         help="Tag torrents with not working tracker status",
     )
     parser.add_argument(
-        "--sites", action="store_true", help="Tag torrents with site names (tracker URL from config.yaml)"
+        "--sites", action="store_true", help="Tag torrents with site names defined in config.yaml"
     )
     parser.add_argument(
         "--tracker-down",

--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -227,12 +227,12 @@ def add_arguments(command, subparser):
     parser.add_argument(
         "--expired",
         action="store_true",
-        help="Tag torrents that have expired an ratio or seeding time, use with filtering by category/tag",
+        help="Tag torrents that have an expired ratio or seeding time (defined in config.yaml)",
     )
     parser.add_argument(
         "--last-activity",
         action="store_true",
-        help="Tag torrents with last activity date (last 24h, 7 days, 30 days, etc)",
+        help="Tag torrents with last activity date (last 1d, 7 days, 30 days, etc)",
     )
     parser.add_argument(
         "--not-linked",
@@ -245,7 +245,7 @@ def add_arguments(command, subparser):
         help="Tag torrents with not working tracker status",
     )
     parser.add_argument(
-        "--sites", action="store_true", help="Tag torrents with site names defined in config.yaml"
+        "--sites", action="store_true", help="Tag torrents with site names (defined in config.yaml)"
     )
     parser.add_argument(
         "--tracker-down",


### PR DESCRIPTION
There is a tracker filter built into QBT that works just the same. I don't see a need to have this as a tag since we also have the `site` tag.