### PR TITLE
tagging: fix handling trackers without all fields

### DIFF
--- a/qbtools/commands/tagging.py
+++ b/qbtools/commands/tagging.py
@@ -110,12 +110,11 @@ def __init__(app, logger):
 
         if app.expired and tracker and t.state_enum.is_complete:
             if (
-                tracker["required_seed_ratio"]
+                "required_seed_ratio" in tracker
                 and t.ratio >= tracker["required_seed_ratio"]
-            ):
-                tags_to_add.append("expired")
-            elif tracker["required_seed_days"] and t.seeding_time >= utils.seconds(
-                tracker["required_seed_days"]
+            ) or (
+                "required_seed_days" in tracker
+                and t.seeding_time >= utils.seconds(tracker["required_seed_days"])
             ):
                 tags_to_add.append("expired")
 


### PR DESCRIPTION
Fix the test for required_seed_days and required_seed_ratio to check if the key is in object otherwise it just throws a KeyError when accessing.

This fixes this error when not specifying either key in the tracker config.

```
03:00:05 PM ERROR: Error executing command: tagging
Traceback (most recent call last):
  File "/app/qbtools.py", line 135, in main
    mod.__init__(app, logger)
    ~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/app/commands/tagging.py", line 113, in __init__
    tracker["required_seed_ratio"]
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'required_seed_ratio'
```